### PR TITLE
Support adding static headers in routes configuration

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -20,6 +20,9 @@ config :spacesuit, routes: %{
       description: "users to [::1]:9090",
       GET: "http://[::1]:9090/:user_id", # ipv6 localhost (thanks osx)
       POST: "http://[::1]:9090/:user_id"
+      add_headers: %{
+        "X-Something-Special" => "Some value"
+      }
     }},
 
     {"/users/something/:user_id", %{

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -19,7 +19,7 @@ config :spacesuit, routes: %{
     { "/users/:user_id", %{
       description: "users to [::1]:9090",
       GET: "http://[::1]:9090/:user_id", # ipv6 localhost (thanks osx)
-      POST: "http://[::1]:9090/:user_id"
+      POST: "http://[::1]:9090/:user_id",
       add_headers: %{
         "X-Something-Special" => "Some value"
       }

--- a/lib/spacesuit.ex
+++ b/lib/spacesuit.ex
@@ -21,8 +21,8 @@ defmodule Spacesuit do
             dispatch: dispatch
            },
            middlewares: [
-             :cowboy_router, Spacesuit.DebugMiddleware, Spacesuit.AuthMiddleware, :cowboy_handler
-             #:cowboy_router, Spacesuit.AuthMiddleware, :cowboy_handler
+             #:cowboy_router, Spacesuit.DebugMiddleware, Spacesuit.AuthMiddleware, :cowboy_handler
+             :cowboy_router, Spacesuit.AuthMiddleware, :cowboy_handler
            ]
          }
     )

--- a/lib/spacesuit/http_server.ex
+++ b/lib/spacesuit/http_server.ex
@@ -5,6 +5,7 @@ defmodule HttpServer do
   @callback has_body(Map.t) :: Boolean.t
   @callback read_body(Map.t) :: any
   @callback body_length(Map.t) :: Integer.t
+  @callback uri(Map.t) :: String.t
 end
 
 defmodule Spacesuit.HttpServer.Cowboy do
@@ -32,6 +33,10 @@ defmodule Spacesuit.HttpServer.Cowboy do
 
   def body_length(req) do
     :cowboy_req.body_length(req)
+  end
+
+  def uri(req) do
+    :cowboy_req.uri(req)
   end
 end
 
@@ -61,5 +66,9 @@ defmodule Spacesuit.HttpServer.Mock do
 
   def body_length(req) do
     String.length(req[:body] || "")
+  end
+
+  def uri(req) do
+    req[:url]
   end
 end

--- a/lib/spacesuit/proxy_handler.ex
+++ b/lib/spacesuit/proxy_handler.ex
@@ -16,7 +16,7 @@ defmodule Spacesuit.ProxyHandler do
     # Prepare some things we'll need
     ups_url     = build_upstream_url(req, state)
     peer        = format_peer(peer)
-    ups_headers = cowboy_to_hackney(headers, peer)
+    ups_headers = cowboy_to_hackney(headers, peer, @http_server.uri(req))
 
     # Make the proxy request
     req = handle_request(req, ups_url, ups_headers, method)
@@ -106,9 +106,10 @@ defmodule Spacesuit.ProxyHandler do
   end
 
   # Convery headers from Cowboy map format to Hackney list format
-  def cowboy_to_hackney(headers, peer) do
+  def cowboy_to_hackney(headers, peer, url) do
     (headers || %{})
       |> Map.put("X-Forwarded-For", peer)
+      |> Map.put("X-Forwarded-Url", url)
       |> Map.drop([ "host", "Host" ])
       |> Map.to_list
   end

--- a/lib/spacesuit/proxy_handler.ex
+++ b/lib/spacesuit/proxy_handler.ex
@@ -16,7 +16,8 @@ defmodule Spacesuit.ProxyHandler do
     # Prepare some things we'll need
     ups_url     = build_upstream_url(req, state)
     peer        = format_peer(peer)
-    ups_headers = cowboy_to_hackney(headers, peer, @http_server.uri(req))
+    all_headers = add_headers_to(headers, state[:add_headers])
+    ups_headers = cowboy_to_hackney(all_headers, peer, @http_server.uri(req))
 
     # Make the proxy request
     req = handle_request(req, ups_url, ups_headers, method)
@@ -105,11 +106,19 @@ defmodule Spacesuit.ProxyHandler do
       |> Enum.join(".")
   end
 
+  # Take static headers from the config and add them to this request
+  def add_headers_to(headers, added_headers) do
+    Map.merge(headers, added_headers)
+  end
+
   # Convery headers from Cowboy map format to Hackney list format
   def cowboy_to_hackney(headers, peer, url) do
+    [[_, _, host | _ ] | _ ] = url
+
     (headers || %{})
       |> Map.put("X-Forwarded-For", peer)
       |> Map.put("X-Forwarded-Url", url)
+      |> Map.put("X-Forwarded-Host", host)
       |> Map.drop([ "host", "Host" ])
       |> Map.to_list
   end

--- a/lib/spacesuit/router.ex
+++ b/lib/spacesuit/router.ex
@@ -37,6 +37,7 @@ defmodule Spacesuit.Router do
       opts
       |> process_verbs
       |> add_all_actions
+      |> process_headers
 
     {route, Spacesuit.ProxyHandler, compiled_opts}
   end
@@ -57,6 +58,22 @@ defmodule Spacesuit.Router do
           memo # do nothing, we just don't have this verb
       end
     end)
+  end
+
+  # Will insert custom headers into each request. Currently only
+  # static headers are supported. Does not modify the casing of
+  # the headers: they will passed as specified in the config.
+  defp process_headers(opts) do
+    case Map.fetch(opts, :add_headers) do
+      {:ok, headers} ->
+        valid_opts = Enum.map(headers, fn({header, value}) ->
+          {to_string(header), to_string(value)}
+        end)
+
+        Map.put(opts, :add_headers, Map.new(valid_opts))
+
+      :error -> opts
+    end
   end
 
   # If the all_actions key is present, let's add them all.

--- a/test/spacesuit_proxy_handler_test.exs
+++ b/test/spacesuit_proxy_handler_test.exs
@@ -22,6 +22,22 @@ defmodule SpacesuitProxyHandlerTest do
     assert "some-cookie-data" = Map.get(processed, "cookie", "empty") 
   end
 
+  test "adding headers specified int he config" do
+    headers = %{
+      "user-agent" => Enum.join([
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:50.0) ",
+        "Gecko/20100101 Firefox/50.0"
+      ], ""),
+      "accept-language" => "en-US,en;q=0.5",
+      "Host" => " localhost:9090"
+    }
+    added_headers = %{ "Add-One" => "1", "Add-Two" => "2"}
+    all_headers = Spacesuit.ProxyHandler.add_headers_to(headers, added_headers)
+
+    assert all_headers["Add-One"] == "1"
+    assert all_headers["Add-Two"] == "2"
+  end
+
   test "converting headers to Hackney format" do
     headers = %{
       "user-agent" => Enum.join([
@@ -33,7 +49,8 @@ defmodule SpacesuitProxyHandlerTest do
     }
 
     peer = Spacesuit.ProxyHandler.format_peer({{127,0,0,1},32767})
-    original_url = "http://localhost:9090"
+    # Cowboy sends the URL through in this format
+    original_url = [[["http", 58], "//", "localhost", [58, "8080"]], "/v1/people/123/things", "", ""]
     processed = Spacesuit.ProxyHandler.cowboy_to_hackney(headers, peer, original_url)
 
     assert {"X-Forwarded-For", "127.0.0.1"} =
@@ -44,6 +61,9 @@ defmodule SpacesuitProxyHandlerTest do
 
     assert {"X-Forwarded-Url", ^original_url} =
       List.keyfind(processed, "X-Forwarded-Url", 0)
+
+    assert {"X-Forwarded-Host", "localhost"} =
+      List.keyfind(processed, "X-Forwarded-Host", 0)
 
     assert nil == List.keyfind(processed, "Host", 0)
   end

--- a/test/spacesuit_proxy_handler_test.exs
+++ b/test/spacesuit_proxy_handler_test.exs
@@ -33,13 +33,17 @@ defmodule SpacesuitProxyHandlerTest do
     }
 
     peer = Spacesuit.ProxyHandler.format_peer({{127,0,0,1},32767})
-    processed = Spacesuit.ProxyHandler.cowboy_to_hackney(headers, peer)
+    original_url = "http://localhost:9090"
+    processed = Spacesuit.ProxyHandler.cowboy_to_hackney(headers, peer, original_url)
 
     assert {"X-Forwarded-For", "127.0.0.1"} =
       List.keyfind(processed, "X-Forwarded-For", 0)
 
     assert {"accept-language", "en-US,en;q=0.5"} =
       List.keyfind(processed, "accept-language", 0)
+
+    assert {"X-Forwarded-Url", ^original_url} =
+      List.keyfind(processed, "X-Forwarded-Url", 0)
 
     assert nil == List.keyfind(processed, "Host", 0)
   end

--- a/test/spacesuit_router_test.exs
+++ b/test/spacesuit_router_test.exs
@@ -8,7 +8,11 @@ defmodule SpacesuitRouterTest do
           'oh-my.example.com' =>
             [{'/somewhere', %{
               description: 'oh my example',
-              all_actions: 'http://example.com'
+              all_actions: 'http://example.com',
+              add_headers: %{
+                'X-Something-Invalid': 123,
+                'X-Something-Awesome': "awesome"
+              }
             }}],
           ':_' =>
             [{'/users/:user_id', %{
@@ -111,5 +115,18 @@ defmodule SpacesuitRouterTest do
     Application.put_env(:spacesuit, :routes, state[:routes])
     assert {'oh-my.example.com', _} = List.first(Spacesuit.Router.load_routes)
     assert {':_', _} = List.last(Spacesuit.Router.load_routes)
+  end
+
+  test "transforms headers into String:String maps", state do
+    %{
+      'oh-my.example.com' => [ route | _ ]
+    } = state[:routes]
+
+    output = Spacesuit.Router.transform_one_route(route)
+    { _route, _handler, handler_opts } = output
+
+    assert map_size(handler_opts[:add_headers]) == 2
+    assert handler_opts[:add_headers]["X-Something-Invalid"] == "123"
+    assert handler_opts[:add_headers]["X-Something-Awesome"] == "awesome"
   end
 end


### PR DESCRIPTION
This will allow arbitrary, static headers to be added to any inbound request for a particular route, via the routes file.  This is done e.g.:

```
  "[...]:_" => [ # Match any hostname/port combination
    { "/users/:user_id", %{
      description: "users to [::1]:9090",
      GET: "http://[::1]:9090/:user_id", # ipv6 localhost (thanks osx)
      POST: "http://[::1]:9090/:user_id"
      add_headers: %{
        "X-Something-Special" => "Some value"
      }
    }},
```

Second, this adds the `X-Forwarded-Host` header to all inbound requests, using the original hostname as the value (per semi-standard proxy behavior).

cc @mosche @epileptic-fish 