### PR TITLE
Gracefully handle responses with empty bodies

### DIFF
--- a/test/spacesuit_proxy_handler_test.exs
+++ b/test/spacesuit_proxy_handler_test.exs
@@ -122,6 +122,14 @@ defmodule SpacesuitProxyHandlerTest do
     assert {:ok, false} = result
   end
 
+  test "handles responses that have a nil upstream (no body)" do
+    assert :ok = Spacesuit.ProxyHandler.handle_reply(200, %{}, [], nil)
+  end
+
+  test "handles responses that have a an empty body" do
+    assert :ok = Spacesuit.ProxyHandler.handle_reply(200, %{}, [], %{})
+  end
+
   test "stream calls complete properly" do
     assert :ok = Spacesuit.ProxyHandler.stream(:done, nil)
   end


### PR DESCRIPTION
This fixes an issue where HEAD requests returned a 204 and should prevent other request types without response bodies from leaving an error in the logs.

cc @epileptic-fish 