### PR TITLE
Relistan/fix proxied headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: elixir
 
 elixir:
-  - 1.4.2
   - 1.6.0
 
 otp_release:
-  - 19.2
   - 20.2.2
 
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,11 @@ language: elixir
 
 elixir:
   - 1.4.2
+  - 1.6.0
 
 otp_release:
   - 19.2
+  - 20.2.2
 
 sudo: required
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.4.2
+FROM elixir:1.6.0
 
 ADD . /spacesuit
 

--- a/lib/mix/tasks/validate_routes.ex
+++ b/lib/mix/tasks/validate_routes.ex
@@ -3,20 +3,20 @@ defmodule Mix.Tasks.ValidateRoutes do
 
   @shortdoc "Validate the routes for an environment"
 
-  @valid_map_keys Spacesuit.Router.get_http_verbs ++
-    [:description, :destination, :all_actions, :uri, :add_headers, :middleware]
+  @valid_map_keys Spacesuit.Router.get_http_verbs() ++
+                    [:description, :destination, :all_actions, :uri, :add_headers, :middleware]
 
   def run(_) do
-    IO.puts "\nValidating Spacesuit Routes"
-    IO.puts "----------------------------\n"
+    IO.puts("\nValidating Spacesuit Routes")
+    IO.puts("----------------------------\n")
 
-    routes = Spacesuit.Router.load_routes
+    routes = Spacesuit.Router.load_routes()
 
     validate_routes(routes)
 
     case :cowboy_router.compile(routes) do
-      {:error, _} -> IO.puts "ERROR: Cowboy unable to compile routes!"
-      _ -> IO.puts "OK: Cowboy compiled successfully"
+      {:error, _} -> IO.puts("ERROR: Cowboy unable to compile routes!")
+      _ -> IO.puts("OK: Cowboy compiled successfully")
     end
   end
 
@@ -26,7 +26,7 @@ defmodule Mix.Tasks.ValidateRoutes do
       raise "Expected path matcher, found #{inspect(path)}"
     end
 
-    IO.puts "Checking: #{path}"
+    IO.puts("Checking: #{path}")
 
     if !is_atom(handler) do
       raise "Expected handler module, found #{inspect(handler)}"
@@ -42,48 +42,51 @@ defmodule Mix.Tasks.ValidateRoutes do
       end
 
       # If this is an http verb, let's make sure we got a proper URI passed to us
-      if key in Spacesuit.Router.get_http_verbs do
+      if key in Spacesuit.Router.get_http_verbs() do
         if is_nil(value) do
           raise "Invalid route URI: nil"
         end
 
-        [ uri, _map ] = value
+        [uri, _map] = value
+
         case uri do
-          %URI{authority: _auth, path: _path, scheme: _scheme} -> :ok
-        _ ->
-          raise "Constructed URI for #{key} appears to be incomplete! #{inspect(args[:uri])}"
-       end
+          %URI{authority: _auth, path: _path, scheme: _scheme} ->
+            :ok
+
+          _ ->
+            raise "Constructed URI for #{key} appears to be incomplete! #{inspect(args[:uri])}"
+        end
       end
     end
 
     if !is_nil(args[:add_headers]) && !is_map(args[:add_headers]) do
-        raise "Expected add_headers option is not a map, #{inspect(args[:add_headers])}"
+      raise "Expected add_headers option is not a map, #{inspect(args[:add_headers])}"
     end
 
     if !is_nil(args[:middleware]) && !is_map(args[:middleware]) do
-        raise "Expected middleware option is not a map, #{inspect(args[:middleware])}"
+      raise "Expected middleware option is not a map, #{inspect(args[:middleware])}"
     end
   end
 
   # The health route has a different format, so just match that one
   def validate_one_route({["/health"], [], Spacesuit.HealthHandler, %{}}) do
-      :ok
+    :ok
   end
 
   def validate_routes(routes) do
     routes
-      |> Enum.each(fn {host, routes} ->
-           if !is_binary(host) do
-             raise "Expected host matcher, found #{inspect(host)}"
-           end
+    |> Enum.each(fn {host, routes} ->
+      if !is_binary(host) do
+        raise "Expected host matcher, found #{inspect(host)}"
+      end
 
-           for route <- routes do
-             validate_one_route(route)
-           end
-         end)
+      for route <- routes do
+        validate_one_route(route)
+      end
+    end)
 
-    IO.puts "----------------------------\n"
-    IO.puts "Generated routes are formatted properly"
+    IO.puts("----------------------------\n")
+    IO.puts("Generated routes are formatted properly")
     :ok
   end
 end

--- a/lib/spacesuit.ex
+++ b/lib/spacesuit.ex
@@ -10,23 +10,24 @@ defmodule Spacesuit do
   @http_port 8080
 
   def start(_type, _args) do
-    Logger.info "Spacesuit starting up on :#{@http_port}"
+    Logger.info("Spacesuit starting up on :#{@http_port}")
 
-    dispatch = Spacesuit.Router.load_routes |> :cowboy_router.compile
+    dispatch = Spacesuit.Router.load_routes() |> :cowboy_router.compile()
 
-    {:ok, _} = :cowboy.start_clear(
-        :http, 100, [port: @http_port],
-        %{
-           env: %{
-            dispatch: dispatch
-           },
-           middlewares: [
-             #:cowboy_router, Spacesuit.DebugMiddleware, Spacesuit.AuthMiddleware, :cowboy_handler
-             :cowboy_router, Spacesuit.CorsMiddleware, Spacesuit.AuthMiddleware, :cowboy_handler
-           ]
-         }
-    )
+    {:ok, _} =
+      :cowboy.start_clear(:http, 100, [port: @http_port], %{
+        env: %{
+          dispatch: dispatch
+        },
+        middlewares: [
+          # :cowboy_router, Spacesuit.DebugMiddleware, Spacesuit.AuthMiddleware, :cowboy_handler
+          :cowboy_router,
+          Spacesuit.CorsMiddleware,
+          Spacesuit.AuthMiddleware,
+          :cowboy_handler
+        ]
+      })
 
-    Spacesuit.Supervisor.start_link
+    Spacesuit.Supervisor.start_link()
   end
 end

--- a/lib/spacesuit/auth_middleware.ex
+++ b/lib/spacesuit/auth_middleware.ex
@@ -2,29 +2,31 @@ defmodule Spacesuit.AuthMiddleware do
   require Logger
   use Elixometer
 
-  @http_server     Application.get_env(:spacesuit, :http_server)
+  @http_server Application.get_env(:spacesuit, :http_server)
 
-  @timed(key: "timed.authMiddleware-handle", units: :millisecond)
+  @timed key: "timed.authMiddleware-handle", units: :millisecond
   def execute(req, env) do
     case req[:headers]["authorization"] do
       nil ->
-        Logger.debug "No auth header"
+        Logger.debug("No auth header")
         {:ok, req, env}
 
       "Bearer " <> token ->
         case session_service()[:enabled] do
           true ->
             handle_bearer_token(req, env, token)
+
           false ->
             {:ok, req, env}
+
           _ ->
-            Logger.warn "Session service :enabled not configured!"
+            Logger.warn("Session service :enabled not configured!")
             {:ok, req, env}
         end
 
       authorization ->
         # TODO we got some header but we don't know what it is
-        Logger.info "Found unknown authorization header! #{authorization}"
+        Logger.info("Found unknown authorization header! #{authorization}")
         {:ok, strip_auth(req), env}
     end
   end
@@ -34,8 +36,10 @@ defmodule Spacesuit.AuthMiddleware do
       case session_service()[:impl].validate_api_token(token) do
         :ok ->
           {:ok, req, env}
-        unexpected -> # Otherwise we blow up the request
-          Logger.error "auth_middleware error: unexpected response - #{inspect(unexpected)}"
+
+        # Otherwise we blow up the request
+        unexpected ->
+          Logger.error("auth_middleware error: unexpected response - #{inspect(unexpected)}")
           error_reply(req, 401, "Bad Authentication Token")
           {:stop, req}
       end
@@ -45,21 +49,19 @@ defmodule Spacesuit.AuthMiddleware do
   end
 
   defp strip_auth(req) do
-    %{ req | headers: Map.delete(req[:headers], "authorization") }
+    %{req | headers: Map.delete(req[:headers], "authorization")}
   end
 
   # should the session service be bypassed for this route?
   defp bypass_session_srv?(env) do
     case get_in(env, [:handler_opts, :middleware, :session_service]) do
       :disabled -> true
-      _         -> false
+      _ -> false
     end
   end
 
   defp error_reply(req, code, message) do
-    msg = Spacesuit.ApiMessage.encode(
-      %Spacesuit.ApiMessage{status: "error", message: message}
-    )
+    msg = Spacesuit.ApiMessage.encode(%Spacesuit.ApiMessage{status: "error", message: message})
     @http_server.reply(code, %{}, msg, req)
   end
 

--- a/lib/spacesuit/cors_middleware.ex
+++ b/lib/spacesuit/cors_middleware.ex
@@ -131,7 +131,7 @@ defmodule Spacesuit.CorsMiddleware do
 
       headers ->
         if valid_control_headers?(headers) do
-          {:ok, %{"Access-Control-Allow-Headers" => Enum.join(headers, ",")}}
+          {:ok, %{"access-control-allow-headers" => Enum.join(headers, ",")}}
         else
           :error
         end
@@ -167,7 +167,7 @@ defmodule Spacesuit.CorsMiddleware do
             allow_headers
             |> Map.merge(origin_headers(origin))
             |> Map.merge(preflight_header())
-            |> Map.put("Access-Control-Allow-Methods", Atom.to_string(method))
+            |> Map.put("access-control-allow-methods", Atom.to_string(method))
 
           {:ok, headers}
         else
@@ -184,12 +184,12 @@ defmodule Spacesuit.CorsMiddleware do
   defp origin_headers(origin) do
     if cors()[:any_origin_allowed] do
       %{
-        "Access-Control-Allow-Origin" => "*"
+        "access-control-allow-origin" => "*"
        }
     else
       %{
-        "Access-Control-Allow-Origin" => origin,
-        "Vary" => "Origin"
+        "access-control-allow-origin" => origin,
+        "vary" => "Origin"
       }
     end
   end
@@ -200,7 +200,7 @@ defmodule Spacesuit.CorsMiddleware do
     if is_nil(max_age) || (max_age < 0) do
       %{}
     else
-      %{"Access-Control-Max-Age" => max_age}
+      %{"access-control-max-age" => max_age}
     end
   end
 

--- a/lib/spacesuit/cors_middleware.ex
+++ b/lib/spacesuit/cors_middleware.ex
@@ -11,50 +11,51 @@ defmodule Spacesuit.CorsMiddleware do
   require Logger
   use Elixometer
 
-  @http_server                    Application.get_env(:spacesuit, :http_server)
-  @supported_http_methods         [:GET, :POST, :PUT, :PATCH, :DELETE, :HEAD, :OPTIONS]
+  @http_server Application.get_env(:spacesuit, :http_server)
+  @supported_http_methods [:GET, :POST, :PUT, :PATCH, :DELETE, :HEAD, :OPTIONS]
 
-  @timed(key: "timed.corsMiddleware-execute", units: :millisecond)
+  @timed key: "timed.corsMiddleware-execute", units: :millisecond
   def execute(req, env) do
-    with {true, :enabled?}      <- enabled?(),
-         {true, :handled_path?} <- handled_path?(req[:path]),
-         {:ok, origin, method}  <- valid_cors_request?(req),
-         {:ok, headers}         <- process_cors(origin, method, req) do
-      handle_success(req, env, headers)
-    else
-      # The whole middleware is disabled
-      {false, :enabled?} ->
-        Logger.debug "CORS middleware disabled, skipping"
-        {:ok, req, env}
+    result =
+      with {true, :enabled?} <- enabled?(),
+           {true, :handled_path?} <- handled_path?(req[:path]),
+           {:ok, origin, method} <- valid_cors_request?(req),
+           {:ok, headers} <- process_cors(origin, method, req) do
+        handle_success(req, env, headers)
+      else
+        # The whole middleware is disabled
+        {false, :enabled?} ->
+          Logger.debug("CORS middleware disabled, skipping")
+          {:ok, req, env}
 
-      {false, :handled_path?} ->
-        Logger.debug "No CORS headers set for #{req[:method]} #{req[:path]}"
-        {:ok, req, env}
+        {false, :handled_path?} ->
+          Logger.debug("No CORS headers set for #{req[:method]} #{req[:path]}")
+          {:ok, req, env}
 
-      # OPTIONS request, we handle these ourselves. So short-circuit
-      # downstream response and send 200
-      {:ok, headers, :handle_ourselves} ->
-        with_resp_headers = @http_server.set_resp_headers(headers, req)
-        @http_server.reply(200, headers, with_resp_headers)
-        {:stop, with_resp_headers}
+        # OPTIONS request, we handle these ourselves. So short-circuit
+        # downstream response and send 200
+        {:ok, headers, :handle_ourselves} ->
+          with_resp_headers = @http_server.set_resp_headers(headers, req)
+          @http_server.reply(200, headers, with_resp_headers)
+          {:stop, with_resp_headers}
 
-      # There were no CORS headers, continue processing
-      {:ok, {:skip, :valid_cors_request?}} ->
-        Logger.debug "No CORS headers set for #{req[:method]} #{req[:path]}"
-        {:ok, req, env}
+        # There were no CORS headers, continue processing
+        {:ok, {:skip, :valid_cors_request?}} ->
+          Logger.debug("No CORS headers set for #{req[:method]} #{req[:path]}")
+          {:ok, req, env}
 
-      # There were CORS headers, but they are invalid or malformed
-      {:error, :invalid, :valid_cors_request?} ->
-        handle_error(req, env)
+        # There were CORS headers, but they are invalid or malformed
+        {:error, :invalid, :valid_cors_request?} ->
+          handle_error(req, env)
 
-      # We got a method that we don't allow processing CORS for
-      {:error, :unsupported, :process_cors} ->
-        handle_error(req, env)
+        # We got a method that we don't allow processing CORS for
+        {:error, :unsupported, :process_cors} ->
+          handle_error(req, env)
 
-      # It was an OPTIONS request but with invalid headers
-      {:error, :invalid_options, :process_cors} ->
-        handle_error(req, env)
-    end
+        # It was an OPTIONS request but with invalid headers
+        {:error, :invalid_options, :process_cors} ->
+          handle_error(req, env)
+      end
   end
 
   # Quick access function for the application settings for this middleware
@@ -71,16 +72,22 @@ defmodule Spacesuit.CorsMiddleware do
   # by all other middlewares.
   defp handle_error(req, _env) do
     origin = req[:headers]["origin"]
-    Logger.warn("""
-      Invalid CORS request:
-        Origin=#{origin}
-        Method=#{req[:method]}
-        ACCESS_CONTROL_REQUEST_HEADERS=#{req[:headers]["access_control_request_headers"]}
-    """ |> String.replace("  ", ""))
 
-    msg = Spacesuit.ApiMessage.encode(
-      %Spacesuit.ApiMessage{status: "error", message: "Invalid CORS request"}
+    Logger.warn(
+      """
+        Invalid CORS request:
+          Origin=#{origin}
+          Method=#{req[:method]}
+          ACCESS_CONTROL_REQUEST_HEADERS=#{req[:headers]["access_control_request_headers"]}
+      """
+      |> String.replace("  ", "")
     )
+
+    msg =
+      Spacesuit.ApiMessage.encode(%Spacesuit.ApiMessage{
+        status: "error",
+        message: "Invalid CORS request"
+      })
 
     @http_server.reply(403, %{}, msg, req)
     {:stop, req}
@@ -94,8 +101,8 @@ defmodule Spacesuit.CorsMiddleware do
 
   # Is the path something we can send a CORS response for?
   defp handled_path?(path) do
-    path_prefixes = (cors()[:path_prefixes] || ["/"])
-    result = Enum.any?(path_prefixes, fn(p) -> String.starts_with?(path, p) end)
+    path_prefixes = cors()[:path_prefixes] || ["/"]
+    result = Enum.any?(path_prefixes, fn p -> String.starts_with?(path, p) end)
     {result, :handled_path?}
   end
 
@@ -110,7 +117,8 @@ defmodule Spacesuit.CorsMiddleware do
       serve_from_origin?(origin) ->
         {:ok, origin, String.to_atom(req[:method])}
 
-      true -> # Default case
+      # Default case
+      true ->
         {:error, :invalid, :valid_cors_request?}
     end
   end
@@ -118,16 +126,18 @@ defmodule Spacesuit.CorsMiddleware do
   # Do we have headers we're allowed to process?
   def verify_access_control_request_headers(req) do
     # Access control request headers come jammed into a single string
-    acr_headers = (req[:headers]["access-control-request-headers"] || "")
-    |> String.split(",")
-    |> Enum.map(&String.downcase/1)
-    |> Enum.map(&String.trim/1)
-    |> Enum.into(MapSet.new)
+    acr_headers =
+      (req[:headers]["access-control-request-headers"] || "")
+      |> String.split(",")
+      |> Enum.map(&String.downcase/1)
+      |> Enum.map(&String.trim/1)
+      |> Enum.into(MapSet.new())
 
     empty_mapset = MapSet.new([""])
 
     case acr_headers do
-      ^empty_mapset -> {:ok, %{}}
+      ^empty_mapset ->
+        {:ok, %{}}
 
       headers ->
         if valid_control_headers?(headers) do
@@ -139,14 +149,14 @@ defmodule Spacesuit.CorsMiddleware do
   end
 
   defp valid_control_headers?(headers) do
-    MapSet.size(access_control_request_headers()) == 0 || MapSet.subset?(headers, access_control_request_headers())
+    MapSet.size(access_control_request_headers()) == 0 ||
+      MapSet.subset?(headers, access_control_request_headers())
   end
 
   defp process_cors(origin, method, req) do
     if method == :OPTIONS do
       case handle_options_method(origin, method, req) do
         :error -> {:error, :invalid_options, :process_cors}
-
         {:ok, headers} -> {:ok, headers, :handle_ourselves}
       end
     else
@@ -162,6 +172,7 @@ defmodule Spacesuit.CorsMiddleware do
     case verify_access_control_request_headers(req) do
       {:ok, allow_headers} ->
         method = String.to_atom(req[:headers]["access-control-request-method"] || "")
+
         if supported_http_method?(method) && allowed_http_method?(method) do
           headers =
             allow_headers
@@ -176,16 +187,15 @@ defmodule Spacesuit.CorsMiddleware do
 
       _ ->
         :error
-
     end
   end
 
-  @spec origin_headers(String.t) :: Map.t
+  @spec origin_headers(String.t()) :: Map.t()
   defp origin_headers(origin) do
     if cors()[:any_origin_allowed] do
       %{
         "access-control-allow-origin" => "*"
-       }
+      }
     else
       %{
         "access-control-allow-origin" => origin,
@@ -194,30 +204,32 @@ defmodule Spacesuit.CorsMiddleware do
     end
   end
 
-  @spec preflight_header() :: Map.t
+  @spec preflight_header() :: Map.t()
   defp preflight_header do
     max_age = cors()[:preflight_max_age]
-    if is_nil(max_age) || (max_age < 0) do
+
+    if is_nil(max_age) || max_age < 0 do
       %{}
     else
       %{"access-control-max-age" => max_age}
     end
   end
 
-  @spec serve_from_origin?(String.t) :: boolean
+  @spec serve_from_origin?(String.t()) :: boolean
   defp serve_from_origin?(origin) do
-    !String.contains?(origin || "", "%") &&
-      !is_nil(URI.parse(origin).scheme) &&
+    !String.contains?(origin || "", "%") && !is_nil(URI.parse(origin).scheme) &&
       allowed_origin?(origin)
   end
 
-  @spec same_origin?(String.t, Req.t) :: boolean
+  @spec same_origin?(String.t(), Req.t()) :: boolean
   defp same_origin?(origin, req) do
     origin_uri = URI.parse(origin)
-    {req[:scheme], req[:host], req[:port]} == {origin_uri.scheme, origin_uri.host, origin_uri.port}
+
+    {req[:scheme], req[:host], req[:port]} ==
+      {origin_uri.scheme, origin_uri.host, origin_uri.port}
   end
 
-  @spec allowed_origin?(String.t) :: boolean
+  @spec allowed_origin?(String.t()) :: boolean
   defp allowed_origin?(origin) do
     allowed_origins = cors()[:allowed_origins]
     is_nil(allowed_origins) || Enum.member?(allowed_origins, origin)
@@ -228,19 +240,17 @@ defmodule Spacesuit.CorsMiddleware do
     Enum.member?(@supported_http_methods, method)
   end
 
-  @spec allowed_http_method?(String.t) :: boolean
+  @spec allowed_http_method?(String.t()) :: boolean
   def allowed_http_method?(method) do
-    is_nil(cors()[:allowed_http_methods]) || (
-        cors()
-        |> Map.get(:allowed_http_methods, [])
-        |> Enum.member?(method)
-      )
+    is_nil(cors()[:allowed_http_methods]) ||
+      cors()
+      |> Map.get(:allowed_http_methods, [])
+      |> Enum.member?(method)
   end
 
   defp access_control_request_headers do
     (cors()[:access_control_request_headers] || [])
     |> Enum.map(&String.downcase/1)
-    |> Enum.into(MapSet.new)
+    |> Enum.into(MapSet.new())
   end
-
 end

--- a/lib/spacesuit/debug_middleware.ex
+++ b/lib/spacesuit/debug_middleware.ex
@@ -5,8 +5,8 @@ defmodule Spacesuit.DebugMiddleware do
   require Logger
 
   def execute(req, env) do
-    Logger.debug inspect(req)
-    Logger.debug inspect(env)
+    Logger.debug(inspect(req))
+    Logger.debug(inspect(env))
     {:ok, req, env}
   end
 end

--- a/lib/spacesuit/health_handler.ex
+++ b/lib/spacesuit/health_handler.ex
@@ -5,14 +5,16 @@ defmodule Spacesuit.HealthHandler do
   @http_server Application.get_env(:spacesuit, :http_server)
 
   # Callback from the Cowboy handler
-  @timed(key: "timed.healthHandler-handle", units: :millisecond)
+  @timed key: "timed.healthHandler-handle", units: :millisecond
   def init(req, state) do
-    msg = Spacesuit.ApiMessage.encode(
-      %Spacesuit.ApiMessage{status: "ok", message: "Spacesuit running OK"}
-    )
+    msg =
+      Spacesuit.ApiMessage.encode(%Spacesuit.ApiMessage{
+        status: "ok",
+        message: "Spacesuit running OK"
+      })
+
     @http_server.reply(200, %{}, msg, req)
-    
+
     {:ok, req, state}
   end
-
 end

--- a/lib/spacesuit/http_client.ex
+++ b/lib/spacesuit/http_client.ex
@@ -1,6 +1,6 @@
 defmodule HttpClient do
-  @callback request(String.t, String.t, [tuple], String.t, List.t) :: any
-  @callback stream_body(String.t) :: any
+  @callback request(String.t(), String.t(), [tuple], String.t(), List.t()) :: any
+  @callback stream_body(String.t()) :: any
 end
 
 defmodule Spacesuit.HttpClient.Hackney do
@@ -39,12 +39,11 @@ defmodule Spacesuit.HttpClient.Mock do
   def stream_body(_body) do
     # TODO figure out a better way to keep state here to make sure we
     # trigger all the conditions all the time
-    { result, _ } =
+    {result, _} =
       [:done, {:ok, "blank"}]
-        |> Enum.shuffle
-        |> List.pop_at(0)
+      |> Enum.shuffle()
+      |> List.pop_at(0)
 
     result
   end
-
 end

--- a/lib/spacesuit/http_server.ex
+++ b/lib/spacesuit/http_server.ex
@@ -1,12 +1,12 @@
 defmodule HttpServer do
-  @callback stream_reply(Integer.t, List.t, Map.t) :: any
-  @callback stream_body(String.t, Integer.t, any) :: any
-  @callback reply(Integer.t, List.t, Atom.t, any) :: any
-  @callback has_body(Map.t) :: Boolean.t
-  @callback read_body(Map.t) :: any
-  @callback body_length(Map.t) :: Integer.t
-  @callback uri(Map.t) :: String.t
-  @callback set_resp_headers(Map.t, Map.t) :: any
+  @callback stream_reply(Integer.t(), List.t(), Map.t()) :: any
+  @callback stream_body(String.t(), Integer.t(), any) :: any
+  @callback reply(Integer.t(), List.t(), Atom.t(), any) :: any
+  @callback has_body(Map.t()) :: Boolean.t()
+  @callback read_body(Map.t()) :: any
+  @callback body_length(Map.t()) :: Integer.t()
+  @callback uri(Map.t()) :: String.t()
+  @callback set_resp_headers(Map.t(), Map.t()) :: any
 end
 
 defmodule Spacesuit.HttpServer.Cowboy do
@@ -86,11 +86,9 @@ defmodule Spacesuit.HttpServer.Mock do
   end
 
   def set_resp_headers(headers, req) do
-    {_, with_resp_headers} = Map.get_and_update(
-      req,
-      :resp_headers,
-      fn h -> {h, Map.merge(h || %{}, headers)} end
-    )
+    {_, with_resp_headers} =
+      Map.get_and_update(req, :resp_headers, fn h -> {h, Map.merge(h || %{}, headers)} end)
+
     with_resp_headers
   end
 end

--- a/lib/spacesuit/proxy_handler.ex
+++ b/lib/spacesuit/proxy_handler.ex
@@ -132,9 +132,9 @@ defmodule Spacesuit.ProxyHandler do
     [[_, _, host | _ ] | _ ] = url
 
     (headers || %{})
-      |> Map.put("X-Forwarded-For", peer)
-      |> Map.put("X-Forwarded-Url", url)
-      |> Map.put("X-Forwarded-Host", host)
+      |> Map.merge(%{"x-forwarded-for" => peer}, fn (_k, a, b) -> "#{a}, #{b}" end)
+      |> Map.put("x-forwarded-url", url)
+      |> Map.put("x-forwarded-host", host)
       |> Map.drop([ "host", "Host" ])
       |> Map.to_list
   end

--- a/mix.exs
+++ b/mix.exs
@@ -46,6 +46,7 @@ defmodule Spacesuit.Mixfile do
       {:hackney, "~> 1.7.1", override: true},
       {:cowboy, github: "extend/cowboy"},
       {:poison, "~> 3.0", override: true},
+      {:jsx, "~> 2.8.0"},
       {:joken, "~> 1.4.1"},
       {:elixometer, github: "pinterest/elixometer"},
       {:exometer_newrelic_reporter, github: "nitro/exometer_newrelic_reporter"},

--- a/mix.exs
+++ b/mix.exs
@@ -3,18 +3,20 @@ defmodule Spacesuit.Mixfile do
   use Mix.Config
 
   def build_embedded? do
-    Mix.env == :prod || Mix.env == :dev
+    Mix.env() == :prod || Mix.env() == :dev
   end
 
   def project do
-    [app: :spacesuit,
-     version: "0.1.0",
-     elixir: "~> 1.4",
-     build_embedded: build_embedded?(),
-     start_permanent: Mix.env == :prod,
-     deps: deps(),
-     test_coverage: [tool: ExCoveralls],
-     preferred_cli_env: [coveralls: :test] ]
+    [
+      app: :spacesuit,
+      version: "0.1.0",
+      elixir: "~> 1.4",
+      build_embedded: build_embedded?(),
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      test_coverage: [tool: ExCoveralls],
+      preferred_cli_env: [coveralls: :test]
+    ]
   end
 
   # Configuration for the OTP application
@@ -23,11 +25,15 @@ defmodule Spacesuit.Mixfile do
   def application do
     [
       applications: [
-        :logger, :cowboy, :hackney, :crypto,
-        :jose, :exometer_newrelic_reporter,
+        :logger,
+        :cowboy,
+        :hackney,
+        :crypto,
+        :jose,
+        :exometer_newrelic_reporter,
         :elixometer
       ],
-      mod: { Spacesuit, [] }
+      mod: {Spacesuit, []}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
-%{"afunix": {:git, "https://github.com/tonyrog/afunix.git", "37611258f5446a578391c23def6ca4565c4c67e7", [tag: "1.0"]},
+%{
+  "afunix": {:git, "https://github.com/tonyrog/afunix.git", "37611258f5446a578391c23def6ca4565c4c67e7", [tag: "1.0"]},
   "amqp_client": {:git, "git://github.com/jbrisbin/amqp_client.git", "0878abe6b40cc202b35d86fae32698598c022f0d", [tag: "rabbitmq-3.3.5"]},
   "apex": {:hex, :apex, "1.1.0", "d7a03b8d3e4d9241bd33d986f7bc440f32987ca92dfbec07d491f85593791c82", [:mix], []},
   "base64url": {:hex, :base64url, "0.0.1", "36a90125f5948e3afd7be97662a1504b934dd5dac78451ca6e9abf85a10286be", [:rebar], []},
@@ -23,6 +24,7 @@
   "jiffy": {:git, "git://github.com/davisp/jiffy.git", "137d3d94b6ee10001d761d412cbbe7f665680c98", [ref: "0.13.3"]},
   "joken": {:hex, :joken, "1.4.1", "16b87dcbad59dfb1e75231b9d6e504d852ce11f849efb7150a41dcad29dba8e1", [:mix], [{:jose, "~> 1.8", [hex: :jose, optional: false]}, {:plug, "~> 1.0", [hex: :plug, optional: true]}, {:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, optional: true]}]},
   "jose": {:hex, :jose, "1.8.1", "840ebf379dbdc36a2856d579d911faefe0810270efa97113423af9f76ca7ca0c", [:mix, :rebar3], [{:base64url, "~> 0.0.1", [hex: :base64url, optional: false]}]},
+  "jsk": {:git, "https://github.com/talentdeficit/jsx.git", "45ffea21a6863c58fb7da1f937e868916ff68b27", []},
   "jsx": {:hex, :jsx, "2.8.1", "1453b4eb3615acb3e2cd0a105d27e6761e2ed2e501ac0b390f5bbec497669846", [:mix, :rebar3], []},
   "lager": {:hex, :lager, "3.2.4", "a6deb74dae7927f46bd13255268308ef03eb206ec784a94eaf7c1c0f3b811615", [:rebar3], [{:goldrush, "0.1.9", [hex: :goldrush, optional: false]}]},
   "lager_logger": {:git, "https://github.com/PSPDFKit-labs/lager_logger.git", "432ebf910d33766338b531a0329a2e7a86f98d84", []},
@@ -37,4 +39,5 @@
   "rabbit_common": {:git, "git://github.com/jbrisbin/rabbit_common.git", "9c1965273032ffb79ec0ff80b250e5d0b4608aa7", [tag: "rabbitmq-3.3.5"]},
   "ranch": {:git, "https://github.com/ninenines/ranch", "40809cd2b257a8a53bcb5588ecaa88cc5381ff5c", [ref: "1.3.0"]},
   "setup": {:hex, :setup, "1.7.0", "15df8e57c6df9755e22bfb1aef0c640bd97e9889396fdfb2a85a5536a9043674", [:rebar3], []},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []}}
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []},
+}

--- a/mix.lock
+++ b/mix.lock
@@ -8,7 +8,7 @@
   "cowboy": {:git, "https://github.com/extend/cowboy.git", "80f8cda7ff8fe6a575b4c2eaedd8451acf4fcef3", []},
   "cowlib": {:git, "https://github.com/ninenines/cowlib", "8e6d0f462850a90bd8a60995f52027839288d038", [ref: "master"]},
   "edown": {:hex, :edown, "0.7.0", "6803599606b10f8e328d6d60c44cd16244cd2429908894c415fce4211c3bfefd", [:make, :rebar], []},
-  "elixometer": {:git, "https://github.com/pinterest/elixometer.git", "8ef021a8b4cd78da6f3477c417b8068b28d5cafc", []},
+  "elixometer": {:git, "https://github.com/pinterest/elixometer.git", "0ef0f2036014e8edc292ec2d3077142af975df73", []},
   "excoveralls": {:hex, :excoveralls, "0.6.1", "9e946b6db84dba592f47632157ecd135a46384b98a430fd16007dc910c70348b", [:mix], [{:exjsx, "~> 3.0", [hex: :exjsx, optional: false]}, {:hackney, ">= 0.12.0", [hex: :hackney, optional: false]}]},
   "exjsx": {:hex, :exjsx, "3.2.1", "1bc5bf1e4fd249104178f0885030bcd75a4526f4d2a1e976f4b428d347614f0f", [:mix], [{:jsx, "~> 2.8.0", [hex: :jsx, optional: false]}]},
   "exometer": {:git, "https://github.com/Feuerlabs/exometer.git", "7a7bd8d2b52de4d90f65aa3f6044b0e988319b9e", []},
@@ -38,6 +38,6 @@
   "poison": {:hex, :poison, "3.0.0", "625ebd64d33ae2e65201c2c14d6c85c27cc8b68f2d0dd37828fde9c6920dd131", [:mix], []},
   "rabbit_common": {:git, "git://github.com/jbrisbin/rabbit_common.git", "9c1965273032ffb79ec0ff80b250e5d0b4608aa7", [tag: "rabbitmq-3.3.5"]},
   "ranch": {:git, "https://github.com/ninenines/ranch", "40809cd2b257a8a53bcb5588ecaa88cc5381ff5c", [ref: "1.3.0"]},
-  "setup": {:hex, :setup, "1.7.0", "15df8e57c6df9755e22bfb1aef0c640bd97e9889396fdfb2a85a5536a9043674", [:rebar3], []},
+  "setup": {:hex, :setup, "1.8.4", "738db0685dc1741f45c6a9bf78478e0d5877f3d0876c0b50fd02f0210edb5aa4", [:rebar3], []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []},
 }

--- a/test/spacesuit_cors_middleware_test.exs
+++ b/test/spacesuit_cors_middleware_test.exs
@@ -49,7 +49,7 @@ defmodule SpacesuitCorsMiddlewareTest do
       env = %{}
 
       {:stop, req2} = Spacesuit.CorsMiddleware.execute(req, env)
-      assert req2[:resp_headers]["Access-Control-Allow-Origin"] == "*"
+      assert req2[:resp_headers]["access-control-allow-origin"] == "*"
     end
 
     test "limits allowed HTTP methods when set" do
@@ -93,7 +93,7 @@ defmodule SpacesuitCorsMiddlewareTest do
       req = Map.merge(state[:req], %{:host => "example.com", :headers => %{"origin" => "http://www.example.com"}})
       env = %{}
       {_, req2, _} = Spacesuit.CorsMiddleware.execute(req, env)
-      assert req2[:resp_headers]["Access-Control-Allow-Origin"] == "http://www.example.com"
+      assert req2[:resp_headers]["access-control-allow-origin"] == "http://www.example.com"
     end
 
     test "does not consider different ports to be the same origin", state do
@@ -105,7 +105,7 @@ defmodule SpacesuitCorsMiddlewareTest do
         })
       env = %{}
       {_, req2, _} = Spacesuit.CorsMiddleware.execute(req, env)
-      assert req2[:resp_headers]["Access-Control-Allow-Origin"] == "http://www.example.com:9000"
+      assert req2[:resp_headers]["access-control-allow-origin"] == "http://www.example.com:9000"
     end
 
     test "does not consider different protocols to be the same origin", state do
@@ -117,7 +117,7 @@ defmodule SpacesuitCorsMiddlewareTest do
         })
       env = %{}
       {_, req2, _} = Spacesuit.CorsMiddleware.execute(req, env)
-      assert req2[:resp_headers]["Access-Control-Allow-Origin"] == "https://www.example.com:9000"
+      assert req2[:resp_headers]["access-control-allow-origin"] == "https://www.example.com:9000"
     end
 
     test "forbids an empty origin header", state do
@@ -143,7 +143,7 @@ defmodule SpacesuitCorsMiddlewareTest do
         state[:req],
         %{
           :method => "OPTIONS",
-          :headers => %{"origin" => "http://localhost", "Access-Control-Request-Method" => ""}
+          :headers => %{"origin" => "http://localhost", "access-control-request-method" => ""}
         })
       env = %{}
       assert {:stop, _} = Spacesuit.CorsMiddleware.execute(req, env)
@@ -152,12 +152,12 @@ defmodule SpacesuitCorsMiddlewareTest do
     test "handles a simple cross-origin request", state do
       {:ok, with_resp_headers, _} = Spacesuit.CorsMiddleware.execute(state[:req], %{})
       resp_headers = with_resp_headers[:resp_headers]
-      assert "http://localhost" = resp_headers["Access-Control-Allow-Origin"]
-      assert is_nil resp_headers["Access-Control-Allow-Headers"]
-      assert is_nil resp_headers["Access-Control-Allow-Methods"]
-      assert is_nil resp_headers["Access-Control-Expose-Headers"]
-      assert is_nil resp_headers["Access-Control-Max-Age"]
-      assert "Origin" = resp_headers["Vary"]
+      assert "http://localhost" = resp_headers["access-control-allow-origin"]
+      assert is_nil resp_headers["access-control-allow-headers"]
+      assert is_nil resp_headers["access-control-allow-methods"]
+      assert is_nil resp_headers["access-control-expose-headers"]
+      assert is_nil resp_headers["access-control-max-age"]
+      assert "Origin" = resp_headers["vary"]
     end
 
     test "handles a basic preflight request", state do
@@ -169,12 +169,12 @@ defmodule SpacesuitCorsMiddlewareTest do
         })
       {:stop, with_resp_headers} = Spacesuit.CorsMiddleware.execute(req, %{})
       resp_headers = with_resp_headers[:resp_headers]
-      assert "http://localhost" = resp_headers["Access-Control-Allow-Origin"]
-      assert is_nil resp_headers["Access-Control-Allow-Headers"]
-      assert "PUT" = resp_headers["Access-Control-Allow-Methods"]
-      assert is_nil resp_headers["Access-Control-Expose-Headers"]
-      assert "3600" = resp_headers["Access-Control-Max-Age"]
-      assert "Origin" = resp_headers["Vary"]
+      assert "http://localhost" = resp_headers["access-control-allow-origin"]
+      assert is_nil resp_headers["access-control-allow-headers"]
+      assert "PUT" = resp_headers["access-control-allow-methods"]
+      assert is_nil resp_headers["access-control-expose-headers"]
+      assert "3600" = resp_headers["access-control-max-age"]
+      assert "Origin" = resp_headers["vary"]
     end
 
     test "should not include access control max age header if option is invalid", state do
@@ -193,7 +193,7 @@ defmodule SpacesuitCorsMiddlewareTest do
           })
         {:stop, with_resp_headers} = Spacesuit.CorsMiddleware.execute(req, %{})
         resp_headers = with_resp_headers[:resp_headers]
-        assert is_nil resp_headers["Access-Control-Max-Age"]
+        assert is_nil resp_headers["access-control-max-age"]
     end
 
   test "handles a preflight request with request headers", state do
@@ -209,12 +209,12 @@ defmodule SpacesuitCorsMiddlewareTest do
       })
       {:stop, with_resp_headers} = Spacesuit.CorsMiddleware.execute(req, %{})
       resp_headers = with_resp_headers[:resp_headers]
-      assert "http://localhost" = resp_headers["Access-Control-Allow-Origin"]
-      assert "x-header1,x-header2" = resp_headers["Access-Control-Allow-Headers"]
-      assert "PUT" = resp_headers["Access-Control-Allow-Methods"]
-      assert is_nil resp_headers["Access-Control-Expose-Headers"]
-      assert "3600" = resp_headers["Access-Control-Max-Age"]
-      assert "Origin" = resp_headers["Vary"]
+      assert "http://localhost" = resp_headers["access-control-allow-origin"]
+      assert "x-header1,x-header2" = resp_headers["access-control-allow-headers"]
+      assert "PUT" = resp_headers["access-control-allow-methods"]
+      assert is_nil resp_headers["access-control-expose-headers"]
+      assert "3600" = resp_headers["access-control-max-age"]
+      assert "Origin" = resp_headers["vary"]
     end
   end
 
@@ -236,6 +236,6 @@ defmodule SpacesuitCorsMiddlewareTest do
 
       {:stop, with_resp_headers} = Spacesuit.CorsMiddleware.execute(req, %{})
       resp_headers = with_resp_headers[:resp_headers]
-      assert "fancy-header" = resp_headers["Access-Control-Allow-Headers"]
+      assert "fancy-header" = resp_headers["access-control-allow-headers"]
   end
 end

--- a/test/spacesuit_cors_middleware_test.exs
+++ b/test/spacesuit_cors_middleware_test.exs
@@ -7,12 +7,13 @@ defmodule SpacesuitCorsMiddlewareTest do
   setup_all do
     req = %{
       :headers => %{"origin" => "http://localhost"},
-      :scheme  => "http",
-      :host    => "www.example.com",
-      :port    => 80,
-      :path    => "/matched",
-      :method  => "GET"
+      :scheme => "http",
+      :host => "www.example.com",
+      :port => 80,
+      :path => "/matched",
+      :method => "GET"
     }
+
     {:ok, req: req}
   end
 
@@ -36,16 +37,16 @@ defmodule SpacesuitCorsMiddlewareTest do
       current = Application.get_env(:spacesuit, :cors)
       Application.put_env(:spacesuit, :cors, Map.merge(current, %{any_origin_allowed: true}))
 
-      req = Map.merge(state[:req],
-        %{
+      req =
+        Map.merge(state[:req], %{
           :host => "example.com",
           :method => "OPTIONS",
           :headers => %{
             "origin" => "http://www.example.com",
             "access-control-request-method" => "GET"
           }
-        }
-      )
+        })
+
       env = %{}
 
       {:stop, req2} = Spacesuit.CorsMiddleware.execute(req, env)
@@ -75,46 +76,53 @@ defmodule SpacesuitCorsMiddlewareTest do
     end
 
     test "passes through same origin requests with a port number", state do
-      req = Map.merge(
-        state[:req],
-        %{:port => 9000, :headers => %{"origin" => "http://www.example.com:9000"}}
-      )
+      req =
+        Map.merge(state[:req], %{
+          :port => 9000,
+          :headers => %{"origin" => "http://www.example.com:9000"}
+        })
+
       env = %{}
       assert {:ok, ^req, ^env} = Spacesuit.CorsMiddleware.execute(req, env)
     end
 
     test "passes through same origin requests without a port number", state do
-      req = Map.merge(state[:req],%{:headers => %{"origin" => "http://www.example.com"}})
+      req = Map.merge(state[:req], %{:headers => %{"origin" => "http://www.example.com"}})
       env = %{}
       assert {:ok, ^req, ^env} = Spacesuit.CorsMiddleware.execute(req, env)
     end
 
     test "does not consider subdomains to be the same origin", state do
-      req = Map.merge(state[:req], %{:host => "example.com", :headers => %{"origin" => "http://www.example.com"}})
+      req =
+        Map.merge(state[:req], %{
+          :host => "example.com",
+          :headers => %{"origin" => "http://www.example.com"}
+        })
+
       env = %{}
       {_, req2, _} = Spacesuit.CorsMiddleware.execute(req, env)
       assert req2[:resp_headers]["access-control-allow-origin"] == "http://www.example.com"
     end
 
     test "does not consider different ports to be the same origin", state do
-      req = Map.merge(
-        state[:req],
-        %{
+      req =
+        Map.merge(state[:req], %{
           :headers => %{"origin" => "http://www.example.com:9000"},
           :host => "www.example.com:9001"
         })
+
       env = %{}
       {_, req2, _} = Spacesuit.CorsMiddleware.execute(req, env)
       assert req2[:resp_headers]["access-control-allow-origin"] == "http://www.example.com:9000"
     end
 
     test "does not consider different protocols to be the same origin", state do
-      req = Map.merge(
-        state[:req],
-        %{
+      req =
+        Map.merge(state[:req], %{
           :headers => %{"origin" => "https://www.example.com:9000"},
           :host => "www.example.com:9000"
         })
+
       env = %{}
       {_, req2, _} = Spacesuit.CorsMiddleware.execute(req, env)
       assert req2[:resp_headers]["access-control-allow-origin"] == "https://www.example.com:9000"
@@ -133,18 +141,18 @@ defmodule SpacesuitCorsMiddlewareTest do
     end
 
     test "forbids an unrecognized HTTP method", state do
-      req = Map.merge(state[:req], %{ :method => "FOO", })
+      req = Map.merge(state[:req], %{:method => "FOO"})
       env = %{}
       assert {:stop, _} = Spacesuit.CorsMiddleware.execute(req, env)
     end
 
     test "forbids an empty Access-Control-Request-Method header in a preflight request", state do
-      req = Map.merge(
-        state[:req],
-        %{
+      req =
+        Map.merge(state[:req], %{
           :method => "OPTIONS",
           :headers => %{"origin" => "http://localhost", "access-control-request-method" => ""}
         })
+
       env = %{}
       assert {:stop, _} = Spacesuit.CorsMiddleware.execute(req, env)
     end
@@ -153,89 +161,97 @@ defmodule SpacesuitCorsMiddlewareTest do
       {:ok, with_resp_headers, _} = Spacesuit.CorsMiddleware.execute(state[:req], %{})
       resp_headers = with_resp_headers[:resp_headers]
       assert "http://localhost" = resp_headers["access-control-allow-origin"]
-      assert is_nil resp_headers["access-control-allow-headers"]
-      assert is_nil resp_headers["access-control-allow-methods"]
-      assert is_nil resp_headers["access-control-expose-headers"]
-      assert is_nil resp_headers["access-control-max-age"]
+      assert is_nil(resp_headers["access-control-allow-headers"])
+      assert is_nil(resp_headers["access-control-allow-methods"])
+      assert is_nil(resp_headers["access-control-expose-headers"])
+      assert is_nil(resp_headers["access-control-max-age"])
       assert "Origin" = resp_headers["vary"]
     end
 
     test "handles a basic preflight request", state do
-      req = Map.merge(
-        state[:req],
-        %{
+      req =
+        Map.merge(state[:req], %{
           :method => "OPTIONS",
           :headers => %{"origin" => "http://localhost", "access-control-request-method" => "PUT"}
         })
+
       {:stop, with_resp_headers} = Spacesuit.CorsMiddleware.execute(req, %{})
       resp_headers = with_resp_headers[:resp_headers]
       assert "http://localhost" = resp_headers["access-control-allow-origin"]
-      assert is_nil resp_headers["access-control-allow-headers"]
+      assert is_nil(resp_headers["access-control-allow-headers"])
       assert "PUT" = resp_headers["access-control-allow-methods"]
-      assert is_nil resp_headers["access-control-expose-headers"]
+      assert is_nil(resp_headers["access-control-expose-headers"])
       assert "3600" = resp_headers["access-control-max-age"]
       assert "Origin" = resp_headers["vary"]
     end
 
     test "should not include access control max age header if option is invalid", state do
-        invalidMaxAge = -1000
-        current = Application.get_env(:spacesuit, :cors)
-        Application.put_env(:spacesuit, :cors, Map.merge(current, %{preflight_max_age: invalidMaxAge}))
+      invalidMaxAge = -1000
+      current = Application.get_env(:spacesuit, :cors)
 
-        req = Map.merge(
-          state[:req],
-          %{
-            :method => "OPTIONS",
-            :headers => %{
-                "origin" => "http://localhost",
-                "access-control-request-method" => "PUT"
-            }
-          })
-        {:stop, with_resp_headers} = Spacesuit.CorsMiddleware.execute(req, %{})
-        resp_headers = with_resp_headers[:resp_headers]
-        assert is_nil resp_headers["access-control-max-age"]
+      Application.put_env(
+        :spacesuit,
+        :cors,
+        Map.merge(current, %{preflight_max_age: invalidMaxAge})
+      )
+
+      req =
+        Map.merge(state[:req], %{
+          :method => "OPTIONS",
+          :headers => %{
+            "origin" => "http://localhost",
+            "access-control-request-method" => "PUT"
+          }
+        })
+
+      {:stop, with_resp_headers} = Spacesuit.CorsMiddleware.execute(req, %{})
+      resp_headers = with_resp_headers[:resp_headers]
+      assert is_nil(resp_headers["access-control-max-age"])
     end
 
-  test "handles a preflight request with request headers", state do
-    req = Map.merge(
-      state[:req],
-      %{
-        :method => "OPTIONS",
-        :headers => %{
-          "origin" => "http://localhost",
-          "access-control-request-method" => "PUT",
-          "access-control-request-headers" => "X-Header1, X-Header2"
-        }
-      })
+    test "handles a preflight request with request headers", state do
+      req =
+        Map.merge(state[:req], %{
+          :method => "OPTIONS",
+          :headers => %{
+            "origin" => "http://localhost",
+            "access-control-request-method" => "PUT",
+            "access-control-request-headers" => "X-Header1, X-Header2"
+          }
+        })
+
       {:stop, with_resp_headers} = Spacesuit.CorsMiddleware.execute(req, %{})
       resp_headers = with_resp_headers[:resp_headers]
       assert "http://localhost" = resp_headers["access-control-allow-origin"]
       assert "x-header1,x-header2" = resp_headers["access-control-allow-headers"]
       assert "PUT" = resp_headers["access-control-allow-methods"]
-      assert is_nil resp_headers["access-control-expose-headers"]
+      assert is_nil(resp_headers["access-control-expose-headers"])
       assert "3600" = resp_headers["access-control-max-age"]
       assert "Origin" = resp_headers["vary"]
     end
   end
 
   test "handles requests with any access control headers if option is empty", state do
+    current = Application.get_env(:spacesuit, :cors)
 
-      current = Application.get_env(:spacesuit, :cors)
-      Application.put_env(:spacesuit, :cors, Map.merge(current, %{access_control_request_headers: nil}))
+    Application.put_env(
+      :spacesuit,
+      :cors,
+      Map.merge(current, %{access_control_request_headers: nil})
+    )
 
-      req = Map.merge(
-      state[:req],
-      %{
-          :method => "OPTIONS",
-          :headers => %{
-              "origin" => "http://localhost",
-              "access-control-request-method" => "PUT",
-              "access-control-request-headers" => "Fancy-header"
-          }
+    req =
+      Map.merge(state[:req], %{
+        :method => "OPTIONS",
+        :headers => %{
+          "origin" => "http://localhost",
+          "access-control-request-method" => "PUT",
+          "access-control-request-headers" => "Fancy-header"
+        }
       })
 
-      {:stop, with_resp_headers} = Spacesuit.CorsMiddleware.execute(req, %{})
-      resp_headers = with_resp_headers[:resp_headers]
-      assert "fancy-header" = resp_headers["access-control-allow-headers"]
+    {:stop, with_resp_headers} = Spacesuit.CorsMiddleware.execute(req, %{})
+    resp_headers = with_resp_headers[:resp_headers]
+    assert "fancy-header" = resp_headers["access-control-allow-headers"]
   end
 end


### PR DESCRIPTION
The real meat of this is [this commit](https://github.com/Nitro/spacesuit/commit/bd93a82cc8ee9ca4ded1551f29f40f39d666838a). The rest is getting this building on Elixir 1.6 and Erlang/OTP 20.2.2 which is a long overdue update.

The main purpose of this is to fix an issue where headers were being duplicated due to the way Cowboy handles down-casing. This should fix issues with multiples copies of CORS headers being sent. It also fixes a situation where we would overwrite X-Forwarded-For addresses instead of appending.

Additionally, Elixir 1.6 shipped with the official code formatter, so all the code has been reformatted. I you want to review the changes just use the single commit above.