### PR TITLE
Turn down 95% of the logging

### DIFF
--- a/lib/spacesuit/proxy_handler.ex
+++ b/lib/spacesuit/proxy_handler.ex
@@ -9,7 +9,7 @@ defmodule Spacesuit.ProxyHandler do
   @timed key: "timed.proxyHandler-handle", units: :millisecond
   def init(req, state) do
     route_name = Map.get(state, :description, "un-named")
-    Logger.info("Processing '#{route_name}'")
+    Logger.debug("Processing '#{route_name}'")
 
     %{method: method, headers: headers, peer: peer} = req
 


### PR DESCRIPTION
This should turn off 95% of the logging for Spacesuit by ending the logging for each request like it does now. Remaining logs will be for warnings, errors, or other important messages.