### PR TITLE
Add scuttle

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,6 +11,12 @@ RUN mix clean
 RUN mix deps.get
 RUN mix compile
 
+RUN wget https://github.com/redboxllc/scuttle/releases/download/v1.3.1/scuttle-linux-amd64.zip \
+  && unzip scuttle-linux-amd64.zip \
+  && mv scuttle /usr/bin \
+  && chmod +x /usr/bin/scuttle \
+  && rm scuttle-linux-amd64.zip
+
 EXPOSE 8080
 
-CMD [ "mix", "run", "--no-halt" ]
+CMD [ "scuttle", "mix", "run", "--no-halt" ]


### PR DESCRIPTION
Ideally, we would not need this thing, but looks like the official New Relic agent for Elixir is a little sketchy. It has a supervisor, and it starts with the application, but if the agent can't connect to the New Relic server at the beginning, it simply doesn't keep retrying.

This tool is used to wait for the sidecar to be ready before starting the application.